### PR TITLE
handle macos install location

### DIFF
--- a/qpm/profiles.py
+++ b/qpm/profiles.py
@@ -1,5 +1,6 @@
 from functools import partial
 from pathlib import Path
+from sys import platform
 from textwrap import dedent
 from typing import List, Optional
 
@@ -50,7 +51,9 @@ class Profile:
         return self.root.exists() and self.root.is_dir()
 
     def cmdline(self) -> List[str]:
-        return ["qutebrowser", "-B", str(self.root), "--qt-arg", "name", self.name] + (
+        return ["qutebrowser" if platform != "darwin" else
+                "/Applications/qutebrowser.app/Contents/MacOS/qutebrowser",
+                "-B", str(self.root), "--qt-arg", "name", self.name] + (
             ["--desktop-file-name", self.name] if self.set_app_id else []
         )
 


### PR DESCRIPTION
On MacOS, qutebrowser is installed as an app by default and isn't available on the path so this modification checks the platform and uses an absolute path to run the qutebrowser binary inside the app. As far as I can tell it works seamlessly otherwise once this modification has been made, though my testing hasn't been too extensive.