### PR TITLE
fix: handle backslashes in sourcing config

### DIFF
--- a/qbpm/profiles.py
+++ b/qbpm/profiles.py
@@ -59,9 +59,18 @@ def create_profile(profile: Profile, overwrite: bool = False) -> bool:
 
     config_dir = profile.root / "config"
     config_dir.mkdir(parents=True, exist_ok=overwrite)
-    userscript_dir = config_dir / "userscripts"
     main_config_dir = user_config_dir() / "userscripts"
+
+    userscript_dir = config_dir / "userscripts"
     os.symlink(main_config_dir,userscript_dir)
+
+    main_data_home = Path(BaseDirectory.xdg_data_home) / "qutebrowser"
+    main_dict = main_data_home / "qtwebengine_dictionaries"
+    data_dir = profile.root / "data"
+    data_dir.mkdir(parents=True, exist_ok=overwrite)
+    dict_dir = data_dir / "qtwebengine_dictionaries"
+    os.symlink(main_dict,dict_dir)
+
     print(profile.root)
     return True
 

--- a/qbpm/profiles.py
+++ b/qbpm/profiles.py
@@ -60,7 +60,7 @@ def create_profile(profile: Profile, overwrite: bool = False) -> bool:
     config_dir = profile.root / "config"
     config_dir.mkdir(parents=True, exist_ok=overwrite)
     userscript_dir = config_dir / "userscripts"
-    main_config_dir = user_config_dir()
+    main_config_dir = user_config_dir() / "userscripts"
     os.symlink(main_config_dir,userscript_dir)
     print(profile.root)
     return True

--- a/qbpm/profiles.py
+++ b/qbpm/profiles.py
@@ -74,7 +74,7 @@ def create_config(
         if home_page:
             out(f"c.url.start_pages = ['{home_page}']")
         main_config_dir = user_config_dir()
-        out(f"config.source('{main_config_dir / 'config.py'}')")
+        out(f"config.source(r'{main_config_dir / 'config.py'}')")
         for conf in main_config_dir.glob("conf.d/*.py"):
             out(f"config.source('{conf}')")
 

--- a/qbpm/profiles.py
+++ b/qbpm/profiles.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 from pathlib import Path
 from sys import platform
@@ -58,6 +59,9 @@ def create_profile(profile: Profile, overwrite: bool = False) -> bool:
 
     config_dir = profile.root / "config"
     config_dir.mkdir(parents=True, exist_ok=overwrite)
+    userscript_dir = config_dir / "userscripts"
+    main_config_dir = user_config_dir()
+    os.symlink(main_config_dir,userscript_dir)
     print(profile.root)
     return True
 


### PR DESCRIPTION
Use string literals to handle backslashes.

Useful with windows paths.