### PR TITLE
Handle backslashes in sourcing config

### DIFF
--- a/qbpm/profiles.py
+++ b/qbpm/profiles.py
@@ -74,7 +74,7 @@ def create_config(
         if home_page:
             out(f"c.url.start_pages = ['{home_page}']")
         main_config_dir = user_config_dir()
-        out(f"config.source('{main_config_dir / 'config.py'}')")
+        out(f"config.source(r'{main_config_dir / 'config.py'}')")
         for conf in main_config_dir.glob("conf.d/*.py"):
             out(f"config.source('{conf}')")
 

--- a/qbpm/profiles.py
+++ b/qbpm/profiles.py
@@ -76,7 +76,7 @@ def create_config(
         main_config_dir = user_config_dir()
         out(f"config.source(r'{main_config_dir / 'config.py'}')")
         for conf in main_config_dir.glob("conf.d/*.py"):
-            out(f"config.source('{conf}')")
+            out(f"config.source(r'{conf}')")
 
 
 application_dir = Path(BaseDirectory.xdg_data_home) / "applications" / "qbpm"


### PR DESCRIPTION
Use string literals to handle backslashes.